### PR TITLE
GitHub action and workflow update

### DIFF
--- a/.github/actions/install-and-cache-node-and-yarn/action.yml
+++ b/.github/actions/install-and-cache-node-and-yarn/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo '::set-output name=dir::$(yarn cache dir)'
+      run: echo 'dir=$(yarn cache dir)' >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache yarn downloads and dependencies

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -62,7 +62,7 @@ jobs:
         run: yarn build && yarn bundle
 
       - name: Cache package
-        if: env.PUBLISH
+        if: ${{ env.PUBLISH }}
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -73,7 +73,7 @@ jobs:
 
   publish:
     name: Publish package
-    if: env.PUBLISH
+    if: ${{ env.PUBLISH }}
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,13 +13,6 @@ jobs:
     name: Set up Node and Yarn packages
     runs-on: ubuntu-latest
     steps:
-      - name: Log variable stuff
-        run: |
-          echo 'github.event_name: ' ${{ github.event_name }}
-          echo 'github.ref_name: ' ${{ github.ref_name }}
-          echo 'condition: ' ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-          echo 'env.PUBLISH: ' ${{ env.PUBLISH }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -61,10 +54,6 @@ jobs:
     outputs:
       PUBLISH: ${{ env.PUBLISH }}
     steps:
-      - name: Log variable stuff
-        run: |
-          echo 'env.PUBLISH: ' ${{ env.PUBLISH }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -75,7 +64,7 @@ jobs:
         run: yarn build && yarn bundle
 
       - name: Cache package
-        if: env.PUBLISH
+        if: env.PUBLISH == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -87,16 +76,12 @@ jobs:
   publish:
     name: Publish package
     needs: build
-    if: needs.build.outputs.PUBLISH
+    if: needs.build.outputs.PUBLISH == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Log variable stuff
-        run: |
-          echo 'needs.build.outputs.PUBLISH: ' ${{ needs.build.outputs.PUBLISH }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,6 +13,13 @@ jobs:
     name: Set up Node and Yarn packages
     runs-on: ubuntu-latest
     steps:
+      - name: Log variable stuff
+        run: |
+          echo 'github.event_name: ' ${{ github.event_name }}
+          echo 'github.ref_name: ' ${{ github.ref_name }}
+          echo 'condition: ' ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          echo 'env.PUBLISH: ' ${{ env.PUBLISH }}
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -54,6 +61,10 @@ jobs:
     outputs:
       PUBLISH: ${{ env.PUBLISH }}
     steps:
+      - name: Log variable stuff
+        run: |
+          echo 'env.PUBLISH: ' ${{ env.PUBLISH }}
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -82,6 +93,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Log variable stuff
+        run: |
+          echo 'needs.build.outputs.PUBLISH: ' ${{ needs.build.outputs.PUBLISH }}
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,10 +3,10 @@
 
 name: Build and publish SDK package
 
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
+
+env:
+  PUBLISH: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
 jobs:
   setup:
@@ -62,6 +62,7 @@ jobs:
         run: yarn build && yarn bundle
 
       - name: Cache package
+        if: $PUBLISH
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -72,6 +73,7 @@ jobs:
 
   publish:
     name: Publish package
+    if: $PUBLISH
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -75,8 +75,8 @@ jobs:
 
   publish:
     name: Publish package
-    if: steps.build.outputs.PUBLISH
     needs: build
+    if: needs.build.outputs.PUBLISH
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -51,6 +51,8 @@ jobs:
     name: Build, bundle and cache package
     needs: setup
     runs-on: ubuntu-latest
+    outputs:
+      PUBLISH: ${{ env.PUBLISH }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -62,7 +64,7 @@ jobs:
         run: yarn build && yarn bundle
 
       - name: Cache package
-        if: ${{ env.PUBLISH }}
+        if: env.PUBLISH
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -73,7 +75,7 @@ jobs:
 
   publish:
     name: Publish package
-    if: ${{ env.PUBLISH }}
+    if: steps.build.outputs.PUBLISH
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -62,7 +62,7 @@ jobs:
         run: yarn build && yarn bundle
 
       - name: Cache package
-        if: $PUBLISH
+        if: env.PUBLISH
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -73,7 +73,7 @@ jobs:
 
   publish:
     name: Publish package
-    if: $PUBLISH
+    if: env.PUBLISH
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
- custom action now uses GITHUB_OUTPUT environment file instead of the set-output command
- build an publish workflow now will run on every push and PR request regardless of the branch but will only try to publish on pushes into the main branch