### PR TITLE
KYC-280: Celo support + subscription duration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kycdao/kycdao-sdk",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "kycDAO SDK for TypeScript and JavaScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export const Blockchains = {
  * @enum
  */
 export const EvmBlockchainNetworks = {
+  CeloAlfajores: 'CeloAlfajores',
+  CeloMainnet: 'CeloMainnet',
   EthereumGoerli: 'EthereumGoerli',
   EthereumMainnet: 'EthereumMainnet',
   PolygonMainnet: 'PolygonMainnet',
@@ -72,6 +74,18 @@ export const TokenImageTypes = {
  * @internal
  */
 export const BlockchainNetworkDetails: Record<BlockchainNetwork, BlockchainNetworkInfo> = {
+  CeloAlfajores: {
+    blockchain: Blockchains.Ethereum,
+    rpcUrl: 'https://alfajores-forno.celo-testnet.org',
+    chainId: '0xaef3',
+    isMainnet: false,
+  },
+  CeloMainnet: {
+    blockchain: Blockchains.Ethereum,
+    rpcUrl: 'https://forno.celo.org',
+    chainId: '0xa4ec',
+    isMainnet: true,
+  },
   EthereumGoerli: {
     blockchain: Blockchains.Ethereum,
     rpcUrl: 'https://rpc.ankr.com/eth_goerli',
@@ -102,7 +116,7 @@ export const BlockchainNetworkDetails: Record<BlockchainNetwork, BlockchainNetwo
   },
   PolygonMumbai: {
     blockchain: Blockchains.Ethereum,
-    rpcUrl: 'https://matic-mumbai.chainstacklabs.com',
+    rpcUrl: 'https://rpc.ankr.com/polygon_mumbai',
     chainId: '0x13881',
     isMainnet: false,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1202,7 +1202,6 @@ export class KycDao extends ApiBase {
           }
           break;
         }
-        // there is no corresponding logic for 'Ethereum':
         default:
           throw new Error(
             `${errorPrefix} - Unsupported blockchain: ${this._chainAndAddress.blockchain}.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,20 @@ export class KycDao extends ApiBase {
     return !!this.user;
   }
 
+  /**
+   * Returns if the current user has a kycDAO subscription. Requires a logged in user.
+   *
+   * @readonly
+   * @type {boolean}
+   */
+  get subscribed(): boolean {
+    if (!this.user) {
+      throw new Error('User login required');
+    }
+
+    return !!this.user.subscription_expiry;
+  }
+
   private verificationStatus: VerificationStatus;
 
   private isVerifiedForType(verificationType: VerificationType): boolean {
@@ -1579,6 +1593,10 @@ export class KycDao extends ApiBase {
 
     const network = chainAndAddress.blockchainNetwork;
 
+    const subscriptionDuration = mintingData.subscriptionYears
+      ? `P${mintingData.subscriptionYears}Y`
+      : undefined;
+
     try {
       const blockchainAccount = this.getBlockchainAccount(chainAndAddress);
 
@@ -1586,6 +1604,7 @@ export class KycDao extends ApiBase {
         blockchain_account_id: blockchainAccount.id,
         network,
         selected_image_id: mintingData.imageId,
+        subscription_duration: subscriptionDuration,
       };
 
       const res = await this.post<MintingAuthorizationResponse>('authorize_minting', data);

--- a/src/types.ts
+++ b/src/types.ts
@@ -581,6 +581,13 @@ export interface MintingData {
    * @type {?string}
    */
   imageId?: string;
+  /**
+   * The number of years for which the user will be subscribed to kycDAO. This will directly influence the expiry time and the minting cost of the token. The default value is 1 year.\
+   * Currently it only has any effect if the user is not subscribed yet, otherwise this value will be ignored. The current user's subscription status can be checked with the {@link KycDao.subscribed}.
+   *
+   * @type {?number}
+   */
+  subscriptionYears?: number;
 }
 
 /* INTERNAL (not in API reference) */
@@ -718,6 +725,7 @@ export interface UserDetails {
   verification_requests: VerificationRequest[];
   blockchain_accounts: BlockchainAccountDetails[];
   available_images: { [imageId: string]: TokenImage };
+  subscription_expiry?: string;
 }
 
 export interface UserUpdateRequest {
@@ -749,6 +757,7 @@ export interface MintingAuthorizationRequest {
   blockchain_account_id: number;
   network: string;
   selected_image_id?: string;
+  subscription_duration?: string;
 }
 
 export interface MintingAuthorizationResponse {


### PR DESCRIPTION
- KYC-280: added Celo networks under Ethereum blockchain, they should be fully supported with our current EVM implementations
- added subscription duration support (years only for now)