### PR TITLE
KYC-505: Unsupported EVM network handling v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kycdao/kycdao-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "kycDAO SDK for TypeScript and JavaScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/blockchains/evm/evm-provider-wrapper.ts
+++ b/src/blockchains/evm/evm-provider-wrapper.ts
@@ -79,6 +79,13 @@ export class EvmProviderWrapper {
     });
   }
 
+  public async switchNetwork(chainId: string): Promise<void> {
+    return this.provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId }],
+    });
+  }
+
   public async personalSign(message: string, address: string): Promise<string> {
     return this.provider.request<string>({
       method: 'personal_sign',

--- a/src/index.ts
+++ b/src/index.ts
@@ -928,11 +928,13 @@ export class KycDao extends ApiBase {
         const blockchainNetwork = typedKeys(networkDetails).find(
           (network) => Number(networkDetails[network].chainId) === Number(chainId),
         );
+        const isSupportedAndEnabled =
+          blockchainNetwork && kycDao.blockchainNetworks.includes(blockchainNetwork);
 
         if (
           kycDao._chainAndAddress &&
           kycDao._chainAndAddress.blockchain === 'Ethereum' &&
-          blockchainNetwork
+          isSupportedAndEnabled
         ) {
           kycDao._chainAndAddress.blockchainNetwork = blockchainNetwork;
         }


### PR DESCRIPTION
The first iteration of this feature does the following things:
- before connection and minting checks if the currently selected EVM network in the wallet provider is supported and enabled in the current kycDAO SDK instance
- if not and there is only one enabled network in the instance it tries to switch the provider's network to that one automatically
- it will throw errors otherwise, allowing the integrating party to ask the user for a manual network change in their wallet provider

It also detects EVM wallet provider chain changes and updates the internal wallet state with the new network, if it's supported and enabled in the current instance.

Also contains manual methods for checking and switching the selected network in the provider (it's only for EVM for now, but later other blockchains can have support for this as well).